### PR TITLE
Settings object can't have a ',' token

### DIFF
--- a/examples/bing-image-search/application.json
+++ b/examples/bing-image-search/application.json
@@ -2,7 +2,7 @@
   "identifier": "{YOUR_IDENTIFIER}",
   "accessKey": "YmluZ2ltYWdlc2VhcmNoOnl2OXg4ZGlrNjhzcHprYWlqT2xC",
   "settings": {
-    "bingApiKey": "d80d5c1e5523455b8bc8dad406587c86",
+    "bingApiKey": "d80d5c1e5523455b8bc8dad406587c86"
   },
   "schemaVersion": 2
 }


### PR DESCRIPTION
This issue make this _example_ break
